### PR TITLE
Tweak calendar recipe and recipe discoveries

### DIFF
--- a/src/main/resources/data/seasons/advancements/recipes/season_calendar.json
+++ b/src/main/resources/data/seasons/advancements/recipes/season_calendar.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "seasons:season_calendar"
+    ]
+  },
+  "criteria": {
+    "has_clock": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:clock"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "seasons:season_calendar"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_clock",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/seasons/advancements/recipes/season_detector.json
+++ b/src/main/resources/data/seasons/advancements/recipes/season_detector.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "seasons:season_detector"
+    ]
+  },
+  "criteria": {
+    "has_detector": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:daylight_detector"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "seasons:season_detector"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_detector",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/seasons/recipes/season_calendar.json
+++ b/src/main/resources/data/seasons/recipes/season_calendar.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
     {
-      "item": "seasons:season_detector"
+      "item": "minecraft:clock"
     },
     {
       "item": "minecraft:book"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -7,6 +7,9 @@
   "authors": [
     "D4rkness_King"
   ],
+  "contributors": [
+    "MokkaCicc"
+  ],
   "contact": {
     "homepage": "https://www.curseforge.com/minecraft/mc-mods/fabric-seasons",
     "sources": "https://github.com/lucaargolo/fabric-seasons",


### PR DESCRIPTION
I tweak the calendar recipe to be less end-game, I make it shapeless with a clock and a book. I try to put it at the same tier than other measure items like the clock or the compass. I keep the detector mid-endgame like other automation items.

Another thing I add is some recipe advancements that unlock the calendar recipe when the player has a clock and the detector recipe when the player has a daylight sensor.