### PR TITLE
Use root locale for all case transitions (should fix #33)

### DIFF
--- a/src/main/java/io/github/lucaargolo/seasons/commands/SeasonCommand.java
+++ b/src/main/java/io/github/lucaargolo/seasons/commands/SeasonCommand.java
@@ -11,6 +11,8 @@ import net.minecraft.text.LiteralText;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.world.World;
 
+import java.util.Locale;
+
 public class SeasonCommand {
 
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
@@ -33,8 +35,8 @@ public class SeasonCommand {
                 .executes(context -> {
                     World world = context.getSource().getWorld();
                     Season season = FabricSeasons.getCurrentSeason(world);
-                    context.getSource().sendFeedback(new TranslatableText("tooltip.seasons.calendar_info_1").append(new TranslatableText("tooltip.seasons."+season.name().toLowerCase())), false);
-                    context.getSource().sendFeedback(new LiteralText(Long.toString(((FabricSeasons.CONFIG.getSeasonLength() - (world.getTimeOfDay() - ((world.getTimeOfDay()/FabricSeasons.CONFIG.getSeasonLength())*FabricSeasons.CONFIG.getSeasonLength()) )) % FabricSeasons.CONFIG.getSeasonLength())/24000L)).append(new TranslatableText("tooltip.seasons.calendar_info_2").append(new TranslatableText("tooltip.seasons."+season.getNext().name().toLowerCase()))), false);
+                    context.getSource().sendFeedback(new TranslatableText("tooltip.seasons.calendar_info_1").append(new TranslatableText("tooltip.seasons."+season.name().toLowerCase(Locale.ROOT))), false);
+                    context.getSource().sendFeedback(new LiteralText(Long.toString(((FabricSeasons.CONFIG.getSeasonLength() - (world.getTimeOfDay() - ((world.getTimeOfDay()/FabricSeasons.CONFIG.getSeasonLength())*FabricSeasons.CONFIG.getSeasonLength()) )) % FabricSeasons.CONFIG.getSeasonLength())/24000L)).append(new TranslatableText("tooltip.seasons.calendar_info_2").append(new TranslatableText("tooltip.seasons."+season.getNext().name().toLowerCase(Locale.ROOT)))), false);
                     return season.ordinal();
                 })
             )

--- a/src/main/java/io/github/lucaargolo/seasons/item/SeasonCalendarItem.java
+++ b/src/main/java/io/github/lucaargolo/seasons/item/SeasonCalendarItem.java
@@ -12,6 +12,7 @@ import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Locale;
 
 public class SeasonCalendarItem extends Item {
 
@@ -25,9 +26,9 @@ public class SeasonCalendarItem extends Item {
         if(world != null) {
             Season season = FabricSeasons.getCurrentSeason(world);
             int seasonLength = FabricSeasons.CONFIG.getSeasonLength();
-            tooltip.add(new TranslatableText("tooltip.seasons.calendar_info_1").append(new TranslatableText("tooltip.seasons."+season.name().toLowerCase())));
+            tooltip.add(new TranslatableText("tooltip.seasons.calendar_info_1").append(new TranslatableText("tooltip.seasons."+season.name().toLowerCase(Locale.ROOT))));
             if(!FabricSeasons.CONFIG.isSeasonLocked() && !FabricSeasons.CONFIG.isSeasonTiedWithSystemTime())
-                tooltip.add(new LiteralText(Long.toString(((seasonLength - (world.getTimeOfDay() - ((world.getTimeOfDay()/seasonLength)*seasonLength) )) % seasonLength)/24000L)).append(new TranslatableText("tooltip.seasons.calendar_info_2").append(new TranslatableText("tooltip.seasons."+season.getNext().name().toLowerCase()))));
+                tooltip.add(new LiteralText(Long.toString(((seasonLength - (world.getTimeOfDay() - ((world.getTimeOfDay()/seasonLength)*seasonLength) )) % seasonLength)/24000L)).append(new TranslatableText("tooltip.seasons.calendar_info_2").append(new TranslatableText("tooltip.seasons."+season.getNext().name().toLowerCase(Locale.ROOT)))));
         }
 
     }

--- a/src/main/java/io/github/lucaargolo/seasons/utils/Season.java
+++ b/src/main/java/io/github/lucaargolo/seasons/utils/Season.java
@@ -2,6 +2,8 @@ package io.github.lucaargolo.seasons.utils;
 
 import net.minecraft.util.StringIdentifiable;
 
+import java.util.Locale;
+
 public enum Season implements StringIdentifiable {
     SPRING,
     SUMMER,
@@ -10,7 +12,7 @@ public enum Season implements StringIdentifiable {
 
     @Override
     public String asString() {
-        return name().toLowerCase();
+        return name().toLowerCase(Locale.ROOT);
     }
 
     public Season getNext() {


### PR DESCRIPTION
Not specifying any locale can cause issues e.g. in the Turkish locale where a `I` in lowercase equals an i with no dot (`ı`).

This should:tm: resolve #33.