### PR TITLE
Config sync

### DIFF
--- a/src/main/java/io/github/lucaargolo/seasons/FabricSeasons.java
+++ b/src/main/java/io/github/lucaargolo/seasons/FabricSeasons.java
@@ -31,7 +31,6 @@ import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/io/github/lucaargolo/seasons/FabricSeasons.java
+++ b/src/main/java/io/github/lucaargolo/seasons/FabricSeasons.java
@@ -70,7 +70,7 @@ public class FabricSeasons implements ModInitializer {
         try {
             if (configFile.createNewFile()) {
                 LOGGER.info("No config file found, creating a new one...");
-                String json = gson.toJson(parser.parse(gson.toJson(new ModConfig())));
+                String json = ConfigToJson(new ModConfig());
                 try (PrintWriter out = new PrintWriter(configFile)) {
                     out.println(json);
                 }
@@ -78,7 +78,8 @@ public class FabricSeasons implements ModInitializer {
                 LOGGER.info("Successfully created default config file.");
             } else {
                 LOGGER.info("A config file was found, loading it..");
-                CONFIG = gson.fromJson(new String(Files.readAllBytes(configFile.toPath())), ModConfig.class);
+                CONFIG = ConfigFromJson(new String(Files.readAllBytes(configFile.toPath())));
+                //CONFIG = gson.fromJson(new String(Files.readAllBytes(configFile.toPath())), ModConfig.class);
                 if(CONFIG == null) {
                     throw new NullPointerException("The config file was empty.");
                 }else{
@@ -299,6 +300,14 @@ public class FabricSeasons implements ModInitializer {
                 }
             }
         }
+    }
+
+    public static String ConfigToJson(ModConfig config){
+        return gson.toJson(parser.parse(gson.toJson(config)));
+    }
+
+    public static ModConfig ConfigFromJson(String json){
+        return gson.fromJson(json, ModConfig.class);
     }
 
 }

--- a/src/main/java/io/github/lucaargolo/seasons/FabricSeasons.java
+++ b/src/main/java/io/github/lucaargolo/seasons/FabricSeasons.java
@@ -28,8 +28,10 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -137,9 +139,16 @@ public class FabricSeasons implements ModInitializer {
             return getCurrentSystemSeason();
         }
         World world = MinecraftClient.getInstance().world;
-        int worldTime = (world != null) ? Math.toIntExact(world.getTimeOfDay()) : 0;
-        int seasonTime = (worldTime / CONFIG.getSeasonLength());
-        return Season.values()[seasonTime % 4];
+
+        if (world != null){
+            RegistryKey<World> dimension = world.getRegistryKey();
+            if (dimension == World.OVERWORLD){
+                int worldTime = (world != null) ? Math.toIntExact(world.getTimeOfDay()) : 0;
+                int seasonTime = (worldTime / CONFIG.getSeasonLength());
+                return Season.values()[seasonTime % 4];
+            }
+        }
+        return FabricSeasonsClient.lastRenderedSeason;
     }
 
     private static Season getCurrentSystemSeason() {

--- a/src/main/java/io/github/lucaargolo/seasons/FabricSeasonsClient.java
+++ b/src/main/java/io/github/lucaargolo/seasons/FabricSeasonsClient.java
@@ -19,7 +19,7 @@ import net.minecraft.util.registry.Registry;
 
 public class FabricSeasonsClient implements ClientModInitializer {
 
-    private static Season lastRenderedSeason = Season.SPRING;
+    public static Season lastRenderedSeason = Season.SPRING;
 
     @Override
     public void onInitializeClient() {

--- a/src/main/java/io/github/lucaargolo/seasons/utils/ConfigSync.java
+++ b/src/main/java/io/github/lucaargolo/seasons/utils/ConfigSync.java
@@ -1,0 +1,65 @@
+package io.github.lucaargolo.seasons.utils;
+
+import io.github.lucaargolo.seasons.FabricSeasons;
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.api.DedicatedServerModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.text.LiteralText;
+import net.minecraft.util.Identifier;
+
+public class ConfigSync implements ClientModInitializer, DedicatedServerModInitializer {
+
+    private static boolean DebugClient = true;
+    private static boolean InitClientOnConnected = false;
+
+    private static final Identifier ConfigSyncAskPacketID = new ModIdentifier("config_sync_ssk");
+    private static final Identifier ConfigSyncResponsePacketID = new ModIdentifier("config_sync_response");
+
+    @Override
+    public void onInitializeClient() {
+        ClientTickEvents.END_CLIENT_TICK.register(client -> {
+            if (client.player != null){
+                if (client.player.age == 1){
+                    String playerName = client.player.getEntityName();
+                    if (!InitClientOnConnected){
+                        //Connected
+                        if(DebugClient) client.player.sendMessage(new LiteralText("[Seasons-Client] Asking Server For Config"), false);
+                        ClientPlayNetworking.send(ConfigSyncAskPacketID, PacketByteBufs.empty());
+                        InitClientOnConnected = true;
+                    }
+                }
+            }
+            else{
+                if (client.world == null) {
+                    InitClientOnConnected = false;
+                }
+            }
+        });
+
+        ClientPlayNetworking.registerGlobalReceiver(ConfigSyncResponsePacketID, (client, handler, buf, responseSender) -> {
+            String json = buf.readString();
+
+            client.execute(() -> {
+                FabricSeasons.CONFIG = FabricSeasons.ConfigFromJson(json);
+                if (client.player != null){
+                    if(DebugClient) client.player.sendMessage(new LiteralText("[Seasons-Client] Received Config From Server"), false);
+                }
+            });
+        });
+    }
+
+    @Override
+    public void onInitializeServer() {
+        ServerPlayNetworking.registerGlobalReceiver(ConfigSyncAskPacketID, (server,player,serverPlayNetworkHandler,byteBuf,packetSender) -> {
+            String json = FabricSeasons.ConfigToJson(FabricSeasons.CONFIG);
+            PacketByteBuf buf = PacketByteBufs.create();
+            buf.writeString(json);
+            ServerPlayNetworking.send(player, ConfigSyncResponsePacketID, buf);
+            server.sendSystemMessage(new LiteralText("[Seasons-Server] Sent Config To " + player.getEntityName()), player.getUuid());
+        });
+    }
+}


### PR DESCRIPTION
Send Config From Server To Client Upon Request.
Should Resolve Season Desync Issues When Clients With Different Config Connect To A Server.
Didn't want to use mixins, and couldn't find an easy way to detect if player just connected to a server, so I used the age of the player entity to detect when to request the config from the server.