### PR TITLE
Add greenhouse glass side culling

### DIFF
--- a/src/main/java/io/github/lucaargolo/seasons/block/GreenhouseGlassBlock.java
+++ b/src/main/java/io/github/lucaargolo/seasons/block/GreenhouseGlassBlock.java
@@ -2,6 +2,8 @@ package io.github.lucaargolo.seasons.block;
 
 import io.github.lucaargolo.seasons.FabricSeasons;
 import io.github.lucaargolo.seasons.blockentities.GreenhouseGlassBlockEntity;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.BlockWithEntity;
@@ -9,6 +11,7 @@ import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityTicker;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 
 public class GreenhouseGlassBlock extends BlockWithEntity {
@@ -30,5 +33,10 @@ public class GreenhouseGlassBlock extends BlockWithEntity {
     @Override
     public BlockRenderType getRenderType(BlockState state) {
         return BlockRenderType.MODEL;
+    }
+
+    @Environment(EnvType.CLIENT)
+    public boolean isSideInvisible(BlockState state, BlockState stateFrom, Direction direction) {
+        return stateFrom.isOf(this);
     }
 }


### PR DESCRIPTION
Changes the rendering on greenhouse glass to better reproduce vanilla glass. Previously, sides of the glass would be visible through the block.