### PR TITLE
Fix #109, Fix #107

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ modrinth_version=2.7.3
 github_api_version=1.314
 
 # Mod Properties
-mod_version=2.0+1.19
+mod_version=2.0.2+1.19
 maven_group=io.github.lucaargolo
 
 # Fabric Properties

--- a/src/main/java/io/github/lucaargolo/seasons/OldSeasonsCompat.java
+++ b/src/main/java/io/github/lucaargolo/seasons/OldSeasonsCompat.java
@@ -11,7 +11,7 @@ import net.minecraft.util.registry.Registry;
 public class OldSeasonsCompat implements ModInitializer {
 	@Override
 	public void onInitialize() {
-		Registry.register(Registry.BLOCK, new ModIdentifier("ice"), new SeasonalIceBlock(FabricBlockSettings.copyOf(Blocks.ICE)));
-		Registry.register(Registry.BLOCK, new ModIdentifier("snow"), new SeasonalSnowBlock(FabricBlockSettings.copyOf(Blocks.SNOW)));
+		Registry.register(Registry.BLOCK, new ModIdentifier("seasonal_ice"), new SeasonalIceBlock(FabricBlockSettings.copyOf(Blocks.ICE)));
+		Registry.register(Registry.BLOCK, new ModIdentifier("seasonal_snow"), new SeasonalSnowBlock(FabricBlockSettings.copyOf(Blocks.SNOW)));
 	}
 }

--- a/src/main/java/io/github/lucaargolo/seasons/OldSeasonsCompat.java
+++ b/src/main/java/io/github/lucaargolo/seasons/OldSeasonsCompat.java
@@ -1,0 +1,17 @@
+package io.github.lucaargolo.seasons;
+
+import io.github.lucaargolo.seasons.block.SeasonalIceBlock;
+import io.github.lucaargolo.seasons.block.SeasonalSnowBlock;
+import io.github.lucaargolo.seasons.utils.ModIdentifier;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+import net.minecraft.block.Blocks;
+import net.minecraft.util.registry.Registry;
+
+public class OldSeasonsCompat implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		Registry.register(Registry.BLOCK, new ModIdentifier("ice"), new SeasonalIceBlock(FabricBlockSettings.copyOf(Blocks.ICE)));
+		Registry.register(Registry.BLOCK, new ModIdentifier("snow"), new SeasonalSnowBlock(FabricBlockSettings.copyOf(Blocks.SNOW)));
+	}
+}

--- a/src/main/java/io/github/lucaargolo/seasons/block/SeasonalIceBlock.java
+++ b/src/main/java/io/github/lucaargolo/seasons/block/SeasonalIceBlock.java
@@ -1,0 +1,37 @@
+package io.github.lucaargolo.seasons.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.IceBlock;
+import net.minecraft.item.Item;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+
+public class SeasonalIceBlock extends IceBlock {
+
+	public SeasonalIceBlock(Settings settings) {
+		super(settings);
+	}
+
+	@Override
+	public void randomTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
+		world.setBlockState(pos, Blocks.ICE.getStateWithProperties(state));
+	}
+
+	@Override
+	public String getTranslationKey() {
+		return Blocks.ICE.getTranslationKey();
+	}
+
+	@Override
+	protected Block asBlock() {
+		return Blocks.ICE;
+	}
+
+	@Override
+	public Item asItem() {
+		return Blocks.ICE.asItem();
+	}
+}

--- a/src/main/java/io/github/lucaargolo/seasons/block/SeasonalSnowBlock.java
+++ b/src/main/java/io/github/lucaargolo/seasons/block/SeasonalSnowBlock.java
@@ -1,0 +1,37 @@
+package io.github.lucaargolo.seasons.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.SnowBlock;
+import net.minecraft.item.Item;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+
+public class SeasonalSnowBlock extends SnowBlock {
+
+	public SeasonalSnowBlock(Settings settings) {
+		super(settings);
+	}
+
+	@Override
+	public void randomTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
+		world.setBlockState(pos, Blocks.SNOW.getStateWithProperties(state));
+	}
+
+	@Override
+	public String getTranslationKey() {
+		return Blocks.SNOW.getTranslationKey();
+	}
+
+	@Override
+	protected Block asBlock() {
+		return Blocks.SNOW;
+	}
+
+	@Override
+	public Item asItem() {
+		return Blocks.SNOW.asItem();
+	}
+}

--- a/src/main/java/io/github/lucaargolo/seasons/utils/CompatWarnState.java
+++ b/src/main/java/io/github/lucaargolo/seasons/utils/CompatWarnState.java
@@ -53,6 +53,7 @@ public class CompatWarnState {
         warnedIds.forEach(s -> list.add(NbtString.of(s)));
         nbt.put("list", list);
         File compatWarnFile = new File(MinecraftClient.getInstance().runDirectory, File.separator+"data"+File.separator+"seasons_compat_warn.nbt");
+        Boolean ignored = compatWarnFile.getParentFile().mkdirs();
         try {
             NbtIo.writeCompressed(nbt, compatWarnFile);
         } catch (IOException e) {

--- a/src/main/java/io/github/lucaargolo/seasons/utils/CompatWarnState.java
+++ b/src/main/java/io/github/lucaargolo/seasons/utils/CompatWarnState.java
@@ -52,9 +52,10 @@ public class CompatWarnState {
         NbtList list = new NbtList();
         warnedIds.forEach(s -> list.add(NbtString.of(s)));
         nbt.put("list", list);
-        File compatWarnFile = new File(MinecraftClient.getInstance().runDirectory, File.separator+"data"+File.separator+"seasons_compat_warn.nbt");
-        Boolean ignored = compatWarnFile.getParentFile().mkdirs();
+        File compatWarnFile = new File(MinecraftClient.getInstance().runDirectory, File.separator+"data"+File.separator+"seasons_compat_warn.dat");
         try {
+            Boolean ignored = compatWarnFile.getParentFile().mkdirs();
+            Boolean ignored2 = compatWarnFile.createNewFile();
             NbtIo.writeCompressed(nbt, compatWarnFile);
         } catch (IOException e) {
             FabricSeasons.LOGGER.error("["+MOD_NAME+"] Failed to save season url warn state.", e);
@@ -63,7 +64,7 @@ public class CompatWarnState {
 
     public static CompatWarnState getState(MinecraftClient client) {
         CompatWarnState state = new CompatWarnState(client);
-        File compatWarnFile = new File(MinecraftClient.getInstance().runDirectory, File.separator+"data"+File.separator+"seasons_compat_warn.nbt");
+        File compatWarnFile = new File(MinecraftClient.getInstance().runDirectory, File.separator+"data"+File.separator+"seasons_compat_warn.dat");
         NbtCompound nbt;
         try {
             nbt = NbtIo.readCompressed(compatWarnFile);

--- a/src/main/resources/assets/seasons/blockstates/seasonal_ice.json
+++ b/src/main/resources/assets/seasons/blockstates/seasonal_ice.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "minecraft:block/ice"
+    }
+  }
+}

--- a/src/main/resources/assets/seasons/blockstates/seasonal_snow.json
+++ b/src/main/resources/assets/seasons/blockstates/seasonal_snow.json
@@ -1,0 +1,28 @@
+{
+  "variants": {
+    "layers=1": {
+      "model": "minecraft:block/snow_height2"
+    },
+    "layers=2": {
+      "model": "minecraft:block/snow_height4"
+    },
+    "layers=3": {
+      "model": "minecraft:block/snow_height6"
+    },
+    "layers=4": {
+      "model": "minecraft:block/snow_height8"
+    },
+    "layers=5": {
+      "model": "minecraft:block/snow_height10"
+    },
+    "layers=6": {
+      "model": "minecraft:block/snow_height12"
+    },
+    "layers=7": {
+      "model": "minecraft:block/snow_height14"
+    },
+    "layers=8": {
+      "model": "minecraft:block/snow_block"
+    }
+  }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,7 +20,8 @@
   "environment": "*",
   "entrypoints": {
     "main": [
-      "io.github.lucaargolo.seasons.FabricSeasons"
+      "io.github.lucaargolo.seasons.FabricSeasons",
+      "io.github.lucaargolo.seasons.OldSeasonsCompat"
     ],
     "client": [
       "io.github.lucaargolo.seasons.FabricSeasonsClient"


### PR DESCRIPTION
 - Adds fallback-registered seasonal ice and snow blocks, that replace themselves with vanilla variants via random tick (Fixes #109)
 - Makes the `.minecraft/data` directory if it doesn't exist (Fixes #107)

Basically just pulled everything from the patched version of extras to make an upgrade-safe version of seasons.

I'll be using this as a custom build for a while, but let me know if anything is out of place.