### PR TITLE
Add config option to control whether frozen biomes that during summer

### DIFF
--- a/src/main/java/io/github/lucaargolo/seasons/FabricSeasons.java
+++ b/src/main/java/io/github/lucaargolo/seasons/FabricSeasons.java
@@ -265,7 +265,9 @@ public class FabricSeasons implements ModInitializer {
             //Frozen Biomes
             switch (season) {
                 case SUMMER -> {
-                    return new Pair<>(Biome.Precipitation.RAIN, temp + 0.3f);
+                    if (CONFIG.shouldSnowyBiomesMeltInSummer())
+                        return new Pair<>(Biome.Precipitation.RAIN, temp + 0.3f);
+                    else return new Pair<>(precipitation, temp);
                 }
                 case WINTER -> {
                     return new Pair<>(Biome.Precipitation.SNOW, temp - 0.2f);

--- a/src/main/java/io/github/lucaargolo/seasons/utils/ModConfig.java
+++ b/src/main/java/io/github/lucaargolo/seasons/utils/ModConfig.java
@@ -23,6 +23,8 @@ public class ModConfig {
     
     private boolean doTemperatureChanges = true;
 
+    private boolean shouldSnowyBiomesMeltInSummer = true;
+
     private List<String> biomeDenylist = List.of(
             "terralith:glacial_chasm"
     );
@@ -55,6 +57,10 @@ public class ModConfig {
 
     public boolean doTemperatureChanges(Identifier biomeId) {
         return doTemperatureChanges && !biomeDenylist.contains(biomeId.toString());
+    }
+
+    public boolean shouldSnowyBiomesMeltInSummer() {
+        return shouldSnowyBiomesMeltInSummer;
     }
 
     public int getSeasonLength() {


### PR DESCRIPTION
This PR adds a config flag, `shouldSnowyBiomesMeltInSummer`. This option defaults to `true` (current behavior). When false, snowy/frozen biomes remain snowy even during summer.

I didn't like the look of the snowy_plains biome during summer, free of snow, and wanted to be able to enjoy seasons while keeping the snowy aesthetic of these biomes during summer.