### PR TITLE
Optimize injectBiomeTemperature

### DIFF
--- a/src/main/java/io/github/lucaargolo/seasons/FabricSeasons.java
+++ b/src/main/java/io/github/lucaargolo/seasons/FabricSeasons.java
@@ -27,7 +27,6 @@ import net.minecraft.item.Item;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.tag.BiomeTags;
 import net.minecraft.tag.TagKey;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Pair;
@@ -37,6 +36,7 @@ import net.minecraft.util.registry.RegistryEntry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.BiomeKeys;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -46,9 +46,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 
 public class FabricSeasons implements ModInitializer {
 
@@ -326,13 +324,17 @@ public class FabricSeasons implements ModInitializer {
         return season;
     }
 
+    private static final TagKey<Biome> IGNORED_CATEGORIES_TAG = TagKey.of(Registry.BIOME_KEY, new Identifier(FabricSeasons.MOD_ID, "ignored"));
+    private static final TagKey<Biome> JUNGLE_LIKE_TAG = TagKey.of(Registry.BIOME_KEY, new Identifier(FabricSeasons.MOD_ID, "jungle_like"));
+
     @SuppressWarnings("ConstantValue")
     public static void injectBiomeTemperature(RegistryEntry<Biome> entry, World world) {
-        List<TagKey<Biome>> ignoredCategories = Arrays.asList(BiomeTags.IS_NETHER, BiomeTags.IS_END, BiomeTags.IS_OCEAN);
-        if(ignoredCategories.stream().anyMatch(entry::isIn)) return;
+        if(entry.isIn(IGNORED_CATEGORIES_TAG))
+            return;
 
+        // legacy, prefer use of tag where possible
         Biome biome = entry.value();
-        Identifier biomeId = entry.getKey().orElse(RegistryKey.of(Registry.BIOME_KEY, new Identifier("plains"))).getValue();
+        Identifier biomeId = entry.getKey().orElse(BiomeKeys.PLAINS).getValue();
         if(!CONFIG.doTemperatureChanges(biomeId)) return;
 
         Biome.Weather currentWeather = biome.weather;
@@ -345,7 +347,7 @@ public class FabricSeasons implements ModInitializer {
         assert weatherAccessor != null;
 
         Season season = FabricSeasons.getCurrentSeason(world);
-        boolean isJungle = entry.isIn(BiomeTags.IS_JUNGLE) || entry.isIn(BiomeTags.HAS_CLOSER_WATER_FOG);
+        boolean isJungle = entry.isIn(JUNGLE_LIKE_TAG);
         Pair<Biome.Precipitation, Float> modifiedWeather = getSeasonWeather(season, biomeId, isJungle, originalWeather.precipitation, originalWeather.temperature);
         weatherAccessor.setPrecipitation(modifiedWeather.getLeft());
         weatherAccessor.setTemperature(modifiedWeather.getRight());

--- a/src/main/resources/data/seasons/tags/worldgen/biome/ignored.json
+++ b/src/main/resources/data/seasons/tags/worldgen/biome/ignored.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_nether",
+    "#minecraft:is_end",
+    "#minecraft:is_ocean"
+  ]
+}

--- a/src/main/resources/data/seasons/tags/worldgen/biome/jungle_like.json
+++ b/src/main/resources/data/seasons/tags/worldgen/biome/jungle_like.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_jungle",
+    "#minecraft:has_closer_water_fog"
+  ]
+}


### PR DESCRIPTION
This PR optimizes `injectBiomeTemperature` by removing unneeded use of streams and recreation of lists. These improvements reduced the tick time impact of this function from 5% to 1.5% in a simple test world. Much of the remaining slowdown is coming from `ModConfig.doTemperatureChanges` and `ModConfig.isValidInDimension`, which repeatedly call `contains` on an ArrayList. Ideally these should be revamped to use tags instead, but I left that out of this PR as it would also break existing configs.

Overall, I also think further optimization is possible around how this function is used in the first place. I have read the prior Discord messages on this topic and while I understand it is a hack to adjust the biome data based on the current season, there shouldn't be a need to do this every single time the biome is accessed. The current code introduces unnecessary lag due to the amount of extra logic being run on every `getBiome` call.