### PR TITLE
Fix the ice not melting after winter has ended due to AbstractBlockMixin.checkIfMeltableAdded being called when a player does not manually place a block. Use a mixin from Block.onPlaced instead.

### DIFF
--- a/src/main/java/io/github/lucaargolo/seasons/mixin/AbstractBlockMixin.java
+++ b/src/main/java/io/github/lucaargolo/seasons/mixin/AbstractBlockMixin.java
@@ -1,6 +1,5 @@
 package io.github.lucaargolo.seasons.mixin;
 
-import io.github.lucaargolo.seasons.FabricSeasons;
 import io.github.lucaargolo.seasons.utils.Meltable;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.BlockState;
@@ -21,12 +20,4 @@ public abstract class AbstractBlockMixin {
             meltableBlock.onMeltableReplaced(serverWorld, pos);
         }
     }
-
-    @Inject(at = @At("HEAD"), method = "onBlockAdded")
-    public void checkIfMeltableAdded(BlockState state, World world, BlockPos pos, BlockState oldState, boolean notify, CallbackInfo ci) {
-        if(!FabricSeasons.isMeltable(pos) && world instanceof ServerWorld serverWorld && state.getBlock() instanceof Meltable meltableBlock) {
-            meltableBlock.onMeltableManuallyPlaced(serverWorld, pos);
-        }
-    }
-
 }

--- a/src/main/java/io/github/lucaargolo/seasons/mixin/BlockMixin.java
+++ b/src/main/java/io/github/lucaargolo/seasons/mixin/BlockMixin.java
@@ -1,0 +1,26 @@
+package io.github.lucaargolo.seasons.mixin;
+
+import io.github.lucaargolo.seasons.FabricSeasons;
+import io.github.lucaargolo.seasons.utils.Meltable;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Block.class)
+public abstract class BlockMixin {
+    @Inject(at = @At("HEAD"), method = "onPlaced")
+    public void onPlaced(World world, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack itemStack, CallbackInfo ci) {
+        if(!FabricSeasons.isMeltable(pos) && world instanceof ServerWorld serverWorld && state.getBlock() instanceof Meltable meltableBlock) {
+            meltableBlock.onMeltableManuallyPlaced(serverWorld, pos);
+        }
+    }
+}

--- a/src/main/resources/seasons.mixins.json
+++ b/src/main/resources/seasons.mixins.json
@@ -7,6 +7,7 @@
     "AbstractBlockMixin",
     "AnimalEntityMixin",
     "BiomeMixin",
+    "BlockMixin",
     "FreezeTopLayerFeatureMixin",
     "IceBlockMixin",
     "LakeFeatureMixin",


### PR DESCRIPTION
Hello, I encountered the issue of "Ice not melting" when winter is over. While running fabric-seasons only I can observe that ice does actually melt when winter is over. The issue seems more apparent when integrated with other mods. One such mod I observed the issue with was Snow! Real Magic! (https://www.curseforge.com/minecraft/mc-mods/snow-real-magic-fabric).

After doing some debugging and adding diagnostics it seems like the sole thing preventing ice from melting is that it was placed "manually". However in my experience the ice is not placed manually it's placed procedurally by using ServerWorld.setBlockState (net.minecraft.class_1937.method_8501). This method will indirectly call BlockState.onBlockAdded which is what the current AbstractBlockMixin targets.

I think an alternative is to use a mixin for Block.onPlaced which appears to be called when a LivingEntity places a block. I'm not entirely sure what the reasoning was to prevent manually placed blocks from melting under the conditions for this mod, but this change will respect those conditions while allowing "naturally" placed "Meltable" blocks to melt outside of winter when mods like Snow! Real Magic! use setBlockState.

Here is a diagnostic log I added to track what was causing this "manually" placed block on my server. 


[00:06:47] [Server thread/INFO]: [Fabric Seasons]] Place meltable translation{key='block.minecraft.ice', args=[]} <- translation{key='block.minecraft.water', args=[]}
[00:06:47] [Server thread/INFO]: 	at net.minecraft.class_4970.handler$gmj000$seasons$checkIfMeltableAdded(class_4970.java:5030)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.class_4970.method_9615(class_4970.java:-1)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.class_4970$class_4971.method_26182(class_4970.java:936)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.class_2818.method_12010(class_2818.java:263)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.class_1937.method_30092(class_1937.java:221)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.class_1937.method_8652(class_1937.java:206)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.class_1937.method_8501(class_1937.java:321)
[00:06:47] [Server thread/INFO]: 	at snownee.snow.WorldTickHandler.tick(WorldTickHandler.java:33)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.class_3218.redirect$gom000$snowrealmagic$cancelVanillaSnow(class_3218.java:26714)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.class_3218.method_18203(class_3218.java:460)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.class_3215.method_14161(class_3215.java:379)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.class_3215.method_12127(class_3215.java:323)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.class_3218.method_18765(class_3218.java:319)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.server.MinecraftServer.method_3813(MinecraftServer.java:875)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.class_3176.method_3813(class_3176.java:289)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.server.MinecraftServer.method_3748(MinecraftServer.java:819)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.server.MinecraftServer.method_29741(MinecraftServer.java:665)
[00:06:47] [Server thread/INFO]: 	at net.minecraft.server.MinecraftServer.method_29739(MinecraftServer.java:257)
[00:06:47] [Server thread/INFO]: 	at java.lang.Thread.run(Thread.java:833)