### PR TITLE
Added snow trample option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # User-specific stuff
+.vscode/
 .idea/
 
 *.iml
@@ -101,6 +102,7 @@ $RECYCLE.BIN/
 *.lnk
 
 .gradle
+bin/
 build/
 
 # Ignore Gradle GUI config

--- a/src/main/java/io/github/lucaargolo/seasons/mixin/ServerWorldMixin.java
+++ b/src/main/java/io/github/lucaargolo/seasons/mixin/ServerWorldMixin.java
@@ -49,7 +49,8 @@ public abstract class ServerWorldMixin extends World implements StructureWorldAc
 
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;precipitationTick(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/world/biome/Biome$Precipitation;)V"), method = "tickChunk", locals = LocalCapture.CAPTURE_FAILSOFT)
     public void setReplacedMeltable(WorldChunk chunk, int randomTickSpeed, CallbackInfo ci, ChunkPos chunkPos, boolean bl, int i, int j, Profiler profiler, BlockPos blockPos, BlockPos blockPos2, Biome biome, int k, Biome.Precipitation precipitation, BlockState blockState3) {
-        Meltable.replaceBlockOnSnow((ServerWorld) (Object) this, blockPos, biome);
+        if (FabricSeasons.CONFIG.shouldSnowReplaceVegetation())
+            Meltable.replaceBlockOnSnow((ServerWorld) (Object) this, blockPos, biome);
     }
 
 }

--- a/src/main/java/io/github/lucaargolo/seasons/utils/ModConfig.java
+++ b/src/main/java/io/github/lucaargolo/seasons/utils/ModConfig.java
@@ -33,6 +33,8 @@ public class ModConfig {
     
     private boolean doTemperatureChanges = true;
 
+    private boolean shouldSnowReplaceVegetation = true;
+
     private boolean shouldSnowyBiomesMeltInSummer = true;
 
     private boolean shouldIceNearWaterMelt = false;
@@ -77,6 +79,10 @@ public class ModConfig {
 
     public boolean doTemperatureChanges(Identifier biomeId) {
         return doTemperatureChanges && !biomeDenylist.contains(biomeId.toString());
+    }
+
+    public boolean shouldSnowReplaceVegetation() {
+        return shouldSnowReplaceVegetation;
     }
 
     public boolean shouldSnowyBiomesMeltInSummer() {


### PR DESCRIPTION
Added the option `shouldSnowReplaceVegetation`, which controls whether snowfalls can replace flowers, grass, and other whatnots.
This defaults to `true` to preserve the behaviour of previous versions.

Feel free to rename the option ot something more consise.