### PR TITLE
Allow seasonal color changes without reloading worldRenderer

### DIFF
--- a/src/main/java/io/github/lucaargolo/seasons/FabricSeasonsClient.java
+++ b/src/main/java/io/github/lucaargolo/seasons/FabricSeasonsClient.java
@@ -60,7 +60,7 @@ public class FabricSeasonsClient implements ClientModInitializer {
         ClientTickEvents.END_WORLD_TICK.register((clientWorld) -> {
             if(FabricSeasons.getCurrentSeason(clientWorld) != lastRenderedSeasonMap.get(clientWorld.getRegistryKey())) {
                 lastRenderedSeasonMap.put(clientWorld.getRegistryKey(), FabricSeasons.getCurrentSeason(clientWorld));
-                MinecraftClient.getInstance().worldRenderer.reload();
+                ((WorldRendererInterface)(MinecraftClient.getInstance().worldRenderer)).reloadOnlyColors();
             }
         });
 

--- a/src/main/java/io/github/lucaargolo/seasons/FabricSeasonsClient.java
+++ b/src/main/java/io/github/lucaargolo/seasons/FabricSeasonsClient.java
@@ -1,6 +1,7 @@
 package io.github.lucaargolo.seasons;
 
 import io.github.lucaargolo.seasons.commands.SeasonDebugCommand;
+import io.github.lucaargolo.seasons.mixed.WorldRendererMixed;
 import io.github.lucaargolo.seasons.resources.CropConfigs;
 import io.github.lucaargolo.seasons.resources.FoliageSeasonColors;
 import io.github.lucaargolo.seasons.resources.GrassSeasonColors;
@@ -60,7 +61,7 @@ public class FabricSeasonsClient implements ClientModInitializer {
         ClientTickEvents.END_WORLD_TICK.register((clientWorld) -> {
             if(FabricSeasons.getCurrentSeason(clientWorld) != lastRenderedSeasonMap.get(clientWorld.getRegistryKey())) {
                 lastRenderedSeasonMap.put(clientWorld.getRegistryKey(), FabricSeasons.getCurrentSeason(clientWorld));
-                ((WorldRendererInterface)(MinecraftClient.getInstance().worldRenderer)).reloadOnlyColors();
+                ((WorldRendererMixed)(MinecraftClient.getInstance().worldRenderer)).reloadOnlyColors();
             }
         });
 

--- a/src/main/java/io/github/lucaargolo/seasons/WorldRendererInterface.java
+++ b/src/main/java/io/github/lucaargolo/seasons/WorldRendererInterface.java
@@ -1,5 +1,0 @@
-package io.github.lucaargolo.seasons;
-
-public abstract interface WorldRendererInterface {
-    void reloadOnlyColors();
-}

--- a/src/main/java/io/github/lucaargolo/seasons/WorldRendererInterface.java
+++ b/src/main/java/io/github/lucaargolo/seasons/WorldRendererInterface.java
@@ -1,0 +1,5 @@
+package io.github.lucaargolo.seasons;
+
+public abstract interface WorldRendererInterface {
+    void reloadOnlyColors();
+}

--- a/src/main/java/io/github/lucaargolo/seasons/mixed/WorldRendererMixed.java
+++ b/src/main/java/io/github/lucaargolo/seasons/mixed/WorldRendererMixed.java
@@ -1,0 +1,5 @@
+package io.github.lucaargolo.seasons.mixed;
+
+public abstract interface WorldRendererMixed {
+    void reloadOnlyColors();
+}

--- a/src/main/java/io/github/lucaargolo/seasons/mixin/WorldRendererMixin.java
+++ b/src/main/java/io/github/lucaargolo/seasons/mixin/WorldRendererMixin.java
@@ -1,18 +1,45 @@
 package io.github.lucaargolo.seasons.mixin;
 
+import io.github.lucaargolo.seasons.WorldRendererInterface;
 import io.github.lucaargolo.seasons.utils.ColorsCache;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.client.render.WorldRenderer;
+import net.minecraft.client.render.chunk.ChunkBuilder;
+import net.minecraft.client.render.chunk.ChunkRendererRegionBuilder;
+import net.minecraft.client.world.ClientWorld;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(WorldRenderer.class)
-public class WorldRendererMixin {
+public abstract class WorldRendererMixin implements WorldRendererInterface {
+
+    @Shadow @Nullable private ClientWorld world;
+    @Shadow @Nullable private ChunkBuilder chunkBuilder;
+
+    @Shadow @Final private ObjectArrayList<WorldRenderer.ChunkInfo> chunkInfos;
 
     @Inject(at = @At("HEAD"), method = "reload()V")
     public void reload(CallbackInfo info) {
         ColorsCache.clearCache();
     }
 
+    @Override
+    public void reloadOnlyColors() {
+        if (this.world == null || this.chunkBuilder == null) {
+            return;
+        }
+        ChunkRendererRegionBuilder chunkRendererRegionBuilder = new ChunkRendererRegionBuilder();
+        this.world.reloadColor();
+
+        for (WorldRenderer.ChunkInfo chunkInfo : this.chunkInfos) {
+            ChunkBuilder.BuiltChunk builtChunk = chunkInfo.chunk;
+            this.chunkBuilder.rebuild(builtChunk, chunkRendererRegionBuilder);
+            builtChunk.cancelRebuild();
+        }
+    }
 }

--- a/src/main/java/io/github/lucaargolo/seasons/mixin/WorldRendererMixin.java
+++ b/src/main/java/io/github/lucaargolo/seasons/mixin/WorldRendererMixin.java
@@ -1,6 +1,6 @@
 package io.github.lucaargolo.seasons.mixin;
 
-import io.github.lucaargolo.seasons.WorldRendererInterface;
+import io.github.lucaargolo.seasons.mixed.WorldRendererMixed;
 import io.github.lucaargolo.seasons.utils.ColorsCache;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.client.render.WorldRenderer;
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(WorldRenderer.class)
-public abstract class WorldRendererMixin implements WorldRendererInterface {
+public abstract class WorldRendererMixin implements WorldRendererMixed {
 
     @Shadow @Nullable private ClientWorld world;
     @Shadow @Nullable private ChunkBuilder chunkBuilder;

--- a/src/main/java/io/github/lucaargolo/seasons/mixin/WorldRendererMixin.java
+++ b/src/main/java/io/github/lucaargolo/seasons/mixin/WorldRendererMixin.java
@@ -33,13 +33,11 @@ public abstract class WorldRendererMixin implements WorldRendererMixed {
         if (this.world == null || this.chunkBuilder == null) {
             return;
         }
-        ChunkRendererRegionBuilder chunkRendererRegionBuilder = new ChunkRendererRegionBuilder();
         this.world.reloadColor();
 
         for (WorldRenderer.ChunkInfo chunkInfo : this.chunkInfos) {
             ChunkBuilder.BuiltChunk builtChunk = chunkInfo.chunk;
-            this.chunkBuilder.rebuild(builtChunk, chunkRendererRegionBuilder);
-            builtChunk.cancelRebuild();
+            builtChunk.scheduleRebuild(true);
         }
     }
 }

--- a/src/main/resources/seasons.accesswidener
+++ b/src/main/resources/seasons.accesswidener
@@ -11,3 +11,4 @@ accessible field net/minecraft/client/option/KeyBinding boundKey Lnet/minecraft/
 accessible method net/minecraft/world/biome/Biome getTemperature (Lnet/minecraft/util/math/BlockPos;)F
 accessible method net/minecraft/client/render/model/json/JsonUnbakedModel$Deserializer resolveReference (Lnet/minecraft/util/Identifier;Ljava/lang/String;)Lcom/mojang/datafixers/util/Either;
 mutable field net/minecraft/client/render/model/json/JsonUnbakedModel textureMap Ljava/util/Map;
+accessible field net/minecraft/client/render/WorldRenderer$ChunkInfo chunk Lnet/minecraft/client/render/chunk/ChunkBuilder$BuiltChunk;


### PR DESCRIPTION
Marking as a draft PR for now because this has no effect with Sodium enabled.
You could get around that with a simple check,
```py
if Sodium:
    worldRenderer.reload(); #same as current implementation
else:
    worldRenderer.reloadOnlyColors(); #new optimized way
```
But I kinda want to see if I can get it fully working both with and without Sodium. Up to you