### PR TITLE
Minor tooltip improvements

### DIFF
--- a/src/main/java/io/github/lucaargolo/seasons/mixin/ItemMixin.java
+++ b/src/main/java/io/github/lucaargolo/seasons/mixin/ItemMixin.java
@@ -11,7 +11,6 @@ import net.minecraft.client.util.InputUtil;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
-import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
@@ -35,40 +34,59 @@ public class ItemMixin {
             Item item = stack.getItem();
             Block block = FabricSeasons.SEEDS_MAP.getOrDefault(item, null);
             if (block != null) {
-                Identifier cropIdentifier = Registries.BLOCK.getId(block);
-                float multiplier = CropConfigs.getSeasonCropMultiplier(cropIdentifier, season);
-                if (multiplier == 0f) {
-                    tooltip.add(Text.translatable("tooltip.seasons.not_grow").formatted(Formatting.RED));
-                } else if (multiplier < 1.0f) {
-                    tooltip.add(Text.translatable("tooltip.seasons.slowed_grow").formatted(Formatting.GOLD));
-                } else if (multiplier == 1.0f) {
-                    tooltip.add(Text.translatable("tooltip.seasons.normal_grow").formatted(Formatting.GREEN));
-                } else {
-                    tooltip.add(Text.translatable("tooltip.seasons.faster_grow").formatted(Formatting.LIGHT_PURPLE));
-                }
+
+
                 MinecraftClient client = MinecraftClient.getInstance();
                 long handle = client.getWindow().getHandle();
                 KeyBinding sneakKey = client.options.sneakKey;
                 InputUtil.Key boundKey = sneakKey.boundKey;
+                Identifier cropIdentifier = Registries.BLOCK.getId(block);
+                float multiplier = CropConfigs.getSeasonCropMultiplier(cropIdentifier, season);
                 boolean sneak = false;
                 if(boundKey.getCategory() == InputUtil.Type.MOUSE) {
                     sneak = GLFW.glfwGetMouseButton(handle, boundKey.getCode()) == 1;
                 }else if(boundKey.getCategory() == InputUtil.Type.KEYSYM) {
                     sneak = GLFW.glfwGetKey(handle, boundKey.getCode()) == 1;
                 }
+                if (multiplier == 0f) {
+                    tooltip.add(Text.translatable("tooltip.seasons.not_grow").formatted(Formatting.RED));
+                } else if (multiplier == 1.0f) {
+                    tooltip.add(Text.translatable("tooltip.seasons.normal_grow").formatted(Formatting.GREEN));
+                }
                 if (sneak) {
+                    if (multiplier != 0f && multiplier < 1.0f) {
+                        tooltip.add(Text.translatable("tooltip.seasons.slowed_grow").formatted(Formatting.GOLD));
+                    } else if (multiplier > 1.0f) {
+                        tooltip.add(Text.translatable("tooltip.seasons.faster_grow").formatted(Formatting.LIGHT_PURPLE));
+                    }
+
                     for (Season s : Season.values()) {
                         if(season == s) {
-                            MutableText text = Text.translatable(s.getTranslationKey()).formatted(s.getFormatting(), Formatting.UNDERLINE);
-                            MutableText multiplierText = Text.literal(String.format("%.1f", (CropConfigs.getSeasonCropMultiplier(cropIdentifier, s) * 100)) + "% speed");
-                            tooltip.add(text.append(Text.literal(": ").append(multiplierText.formatted(s.getFormatting()))));
-                        }else{
-                            MutableText text = Text.translatable(s.getTranslationKey()).formatted(s.getFormatting());
-                            MutableText multiplierText = Text.literal(String.format("%.1f", (CropConfigs.getSeasonCropMultiplier(cropIdentifier, s) * 100)) + "% speed");
-                            tooltip.add(text.append(Text.literal(": ").append(multiplierText.formatted(Formatting.WHITE))));
+                            tooltip.add(Text.translatable("tooltip.seasons.season_speed",
+                                    Text.translatable(s.getTranslationKey()).formatted(s.getFormatting(), Formatting.UNDERLINE),
+                                    Text.translatable("tooltip.seasons.season_delimitator").formatted(s.getFormatting()),
+                                    Text.literal(String.format("%.1f", (CropConfigs.getSeasonCropMultiplier(cropIdentifier, s) * 100))).formatted(Formatting.WHITE)
+                            ));
+                        } else{
+                            tooltip.add(Text.translatable("tooltip.seasons.season_speed",
+                                    Text.translatable(s.getTranslationKey()).formatted(s.getFormatting()),
+                                    Text.translatable("tooltip.seasons.season_delimitator").formatted(s.getFormatting()),
+                                    Text.literal(String.format("%.1f", (CropConfigs.getSeasonCropMultiplier(cropIdentifier, s) * 100)))).formatted(Formatting.GRAY)
+                            );
                         }
                     }
-                }else {
+                } else {
+                    if (multiplier != 0f && multiplier < 1.0f) {
+                        tooltip.add(Text.translatable("tooltip.seasons.combined_grow",
+                                Text.translatable("tooltip.seasons.slowed_grow"),
+                                String.format("%.1f", (CropConfigs.getSeasonCropMultiplier(cropIdentifier, season) * 100))).formatted(Formatting.GOLD)
+                        );
+                    } else if (multiplier > 1.0f) {
+                        tooltip.add(Text.translatable("tooltip.seasons.combined_grow",
+                                Text.translatable("tooltip.seasons.faster_grow"),
+                                String.format("%.1f", (CropConfigs.getSeasonCropMultiplier(cropIdentifier, season) * 100))).formatted(Formatting.LIGHT_PURPLE)
+                        );
+                    }
                     tooltip.add(Text.translatable("tooltip.seasons.show_more", sneakKey.getBoundKeyLocalizedText().copy().formatted(Formatting.BLUE)).formatted(Formatting.GRAY));
                 }
             }
@@ -76,3 +94,4 @@ public class ItemMixin {
     }
 
 }
+

--- a/src/main/resources/assets/seasons/lang/en_us.json
+++ b/src/main/resources/assets/seasons/lang/en_us.json
@@ -8,6 +8,9 @@
   "tooltip.seasons.slowed_grow": "Grows slower this season",
   "tooltip.seasons.not_grow": "Won't grow this season",
   "tooltip.seasons.show_more": "Press %s to show more",
+  "tooltip.seasons.season_delimitator": ": ",
+  "tooltip.seasons.season_speed": "%s%s%s%% speed",
+  "tooltip.seasons.combined_grow": "%s (%s%%)",
 
   "chat.seasons.mod_installed": "Looks like you have %s installed!",
   "chat.seasons.compatibility": "Get full Fabric Seasons compatibility installing the addon.",


### PR DESCRIPTION
- allows for "% speed" text and ": " delimitator to be configured via resource pack lang file
- shows crop growth percentage without holding sneak key if it is not equal to Vanilla or 0
- slightly tweaked colors to be more readable

Before:

![image](https://github.com/lucaargolo/fabric-seasons/assets/57331134/d3279858-108c-446b-9243-e62726742791)

![image](https://github.com/lucaargolo/fabric-seasons/assets/57331134/5ec0253f-276a-4ff5-b472-0ebb93012c64)

After:

![image](https://github.com/lucaargolo/fabric-seasons/assets/57331134/9ed2dc1f-3ad2-44ec-8457-a016cc3d99ad)

![image](https://github.com/lucaargolo/fabric-seasons/assets/57331134/51bf809f-7c98-4b60-b889-d0b71e042b1e)

